### PR TITLE
Fix release workflow tag handling and bump crate to 0.3.1

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -34,10 +34,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine tag name
-        id: tag
+      - name: Resolve release version and image repository
+        id: version
         run: |
-          echo "ref_name=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+          CRATE_VERSION=$(sed -nE 's/^version = "([^"]+)"/\1/p' Cargo.toml | head -n1)
+          if [ -z "${CRATE_VERSION}" ]; then
+            echo "::error::Could not determine crate version from Cargo.toml"
+            exit 1
+          fi
+
+          RELEASE_TAG="v${CRATE_VERSION}"
+          IMAGE_REPO="ghcr.io/${GITHUB_REPOSITORY,,}"
+
+          echo "crate_version=${CRATE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "${RELEASE_TAG}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${CRATE_VERSION} (expected ${RELEASE_TAG})"
+            exit 1
+          fi
 
       - name: Build and push multi-arch Docker image
         uses: docker/build-push-action@v6
@@ -47,8 +63,9 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/rust-cargo-docs-rag-mcp:${{ steps.tag.outputs.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/rust-cargo-docs-rag-mcp:latest
+            ${{ steps.version.outputs.image_repo }}:${{ steps.version.outputs.release_tag }}
+            ${{ steps.version.outputs.image_repo }}:${{ steps.version.outputs.crate_version }}
+            ${{ steps.version.outputs.image_repo }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -56,7 +73,8 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.tag.outputs.ref_name }}
+          tag_name: ${{ steps.version.outputs.release_tag }}
+          target_commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "rust-cargo-docs-rag-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-cargo-docs-rag-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Rust Documentation MCP Server for LLM crate assistance"
 authors = ["Brian Horakh <brianh@promptexecution.com>",

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Repository requirements:
 
 Prebuilt images are published to GitHub Container Registry (GHCR) on release tags.
 
-Pull the image (replace OWNER with the GH org or username that owns the repo; tags look like v0.3.0):
+Pull the image (replace OWNER with the GH org or username that owns the repo; tags look like v0.3.1):
 ```bash
 docker pull ghcr.io/promptexecution/rust-cargo-docs-rag-mcp:latest
 # or a specific version:
-docker pull ghcr.io/promptexecution/rust-cargo-docs-rag-mcp:v0.3.0
+docker pull ghcr.io/promptexecution/rust-cargo-docs-rag-mcp:v0.3.1
 ```
 
 Run the container in HTTP mode (default):

--- a/cog.toml
+++ b/cog.toml
@@ -14,7 +14,7 @@ pre_bump_hooks = [
 ]
 
 post_bump_hooks = [
-  "git add Cargo.toml Cargo.lock CHANGELOG.md"
+  "git add Cargo.toml Cargo.lock server.json CHANGELOG.md"
 ]
 
 [[packages]]

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -50,3 +50,21 @@ if not updated:
 
 path.write_text("\n".join(out_lines) + "\n")
 PY
+
+# Update server.json version and OCI package tag
+python3 - "$version" <<'PY'
+import json, pathlib, sys
+version = sys.argv[1]
+path = pathlib.Path("server.json")
+data = json.loads(path.read_text())
+data["version"] = version
+
+for pkg in data.get("packages", []):
+    if pkg.get("registryType") != "oci":
+        continue
+    ident = pkg.get("identifier")
+    if isinstance(ident, str) and ":" in ident:
+        pkg["identifier"] = f"{ident.rsplit(':', 1)[0]}:{version}"
+
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/promptexecution/rust-cargo-docs-rag-mcp",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/promptexecution/rust-cargo-docs-rag-mcp:0.3.0",
+      "identifier": "ghcr.io/promptexecution/rust-cargo-docs-rag-mcp:0.3.1",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- fix GHCR push failure by lowercasing the image repository name
- drive release tagging from Cargo.toml version and validate pushed tag matches crate version
- keep container tags aligned by pushing `vX.Y.Z`, `X.Y.Z`, and `latest`
- bump crate version to `0.3.1` and sync `server.json`
- update version bump hook to include `server.json` in automated bumps

## Validation
- cargo check --locked

## Context
Fixes failing Actions run/job: https://github.com/PromptExecution/rust-cargo-docs-rag-mcp/actions/runs/21807304139/job/62912761753
